### PR TITLE
Using SCHEMAS env var to address issue with local refs

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -96,6 +96,9 @@ function crawl(obj, path, pathFromRoot, parents, $refs, options) {
 function dereference$Ref($ref, path, pathFromRoot, parents, $refs, options) {
   debug('Dereferencing $ref pointer "%s" at %s', $ref.$ref, path);
 
+  if (process.env.SCHEMAS && !/^https?:\/\//i.test($ref.$ref) && !/^\#/.test($ref.$ref))
+    path = process.env.SCHEMAS;
+    
   var $refPath = url.resolve(path, $ref.$ref);
   var pointer = $refs._resolve($refPath, options);
 

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -92,6 +92,9 @@ function crawl(obj, path, $refs, options) {
 function resolve$Ref($ref, path, $refs, options) {
   debug('Resolving $ref pointer "%s" at %s', $ref.$ref, path);
 
+  if (process.env.SCHEMAS && !/^https?:\/\//i.test($ref.$ref) && !/^\#/.test($ref.$ref))
+    path = process.env.SCHEMAS;
+    
   var resolvedPath = url.resolve(path, $ref.$ref);
   var withoutHash = url.stripHash(resolvedPath);
 


### PR DESCRIPTION
I ran into a problem with local relative file references and addressed it it with the follow.

I assume you would not want to accept this pull request due to the nature of the 'fix', as it uses a env var as a work around, but I thought I'd make you aware of this issue as someone with familiarity with the code base probably have a better idea of how to address it more elegantly and this explains the issue I ran into.

The problem I had was with local relative file references that are nested.

e.g.

* Define a **Place** schema.
* Define a **Person** schema references **PostalAddress** object in **Place** schema (with $ref: "schemas/Place#/definitions/PostalAddress").
* Define a **Organization** schema references **Person** schema (with $ref: "schemas/Person").

In this case, Person will instatiate correctly, but Organization fails when it tries to load Person as the path to the schema file for the Place object is wrong.

Instead of 'schemas/Person.json#/definitions/PostalAddress' it tries to load it as  'schemas /schemas/Person#/definitions/PostalAddress' .

I am inelegantly solving it by allowing the setting of a SCHEMAS environment variable, which is used as the root path for all reference to local schema files if it is set.

It is possible I've just been doing it wrong (if so I'd appreciate feedback on that) and if not it could still be solved much more nicely if anyone has the time to think through the options. In my case I'm allow people to configure where schemas are located in my app using a SCHEMAS env var in any case, so it just made sense to leverage it.

I appreciate it's also possible to solve it by using *absolute* paths to local files, but think that's undesirable as code would need to be deployed to the same location on every platform.