### PR TITLE
adding support for "browser" field, making inclusion in the browser more robust.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "release": "npm run upgrade && npm test && npm run bump && npm publish",
     "start": "npm run watch & http-server -o -c-1"
   },
+  "browser": {
+    "fs": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/BigstickCarpet/json-schema-ref-parser.git"


### PR DESCRIPTION
Adding the "browser" field to package.json.
For details, see: https://github.com/defunctzombie/package-browser-field-spec

Useful when one is not using bower to install this package. Atleast webpack seems to pick this up without issue.
Webpack seems to support it - seems like an elegant solution for mixed usage libraries. 

Seems to be a better solution than #27 https://github.com/BigstickCarpet/json-schema-ref-parser/issues/27