### PR TITLE
Fix missing protocol variable in http.js

### DIFF
--- a/lib/resolvers/http.js
+++ b/lib/resolvers/http.js
@@ -148,6 +148,7 @@ function get (u, httpOptions) {
       port: u.port,
       path: u.path,
       auth: u.auth,
+      protocol: u.protocol,
       headers: httpOptions.headers || {},
       withCredentials: httpOptions.withCredentials
     });


### PR DESCRIPTION
Hi,

the protocol wasn't present in the HTTP/HTTPS Get request.
Fixes #58 and maybe partial #46.