### PR TITLE
fix bundle producing schema with corrupted refs in some cases

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -20,7 +20,7 @@ function bundle (parser, options) {
 
   // Build an inventory of all $ref pointers in the JSON Schema
   var inventory = [];
-  crawl(parser, 'schema', parser.$refs._root$Ref.path + '#', '#', inventory, parser.$refs, options);
+  crawl(parser, 'schema', parser.$refs._root$Ref.path + '#', '#', inventory, parser.$refs, 0, options);
 
   // Remap all $ref pointers
   remap(inventory);
@@ -37,12 +37,12 @@ function bundle (parser, options) {
  * @param {$Refs} $refs
  * @param {$RefParserOptions} options
  */
-function crawl (parent, key, path, pathFromRoot, inventory, $refs, options) {
+function crawl (parent, key, path, pathFromRoot, inventory, $refs, seq, options) {
   var obj = key === null ? parent : parent[key];
 
   if (obj && typeof obj === 'object') {
     if ($Ref.isAllowed$Ref(obj)) {
-      inventory$Ref(parent, key, path, pathFromRoot, inventory, $refs, options);
+      inventory$Ref(parent, key, path, pathFromRoot, inventory, $refs, seq++, options);
     }
     else {
       var keys = Object.keys(obj);
@@ -60,10 +60,10 @@ function crawl (parent, key, path, pathFromRoot, inventory, $refs, options) {
         var value = obj[key];
 
         if ($Ref.isAllowed$Ref(value)) {
-          inventory$Ref(obj, key, path, keyPathFromRoot, inventory, $refs, options);
+          inventory$Ref(obj, key, path, keyPathFromRoot, inventory, $refs, seq++, options);
         }
         else {
-          crawl(obj, key, keyPath, keyPathFromRoot, inventory, $refs, options);
+          crawl(obj, key, keyPath, keyPathFromRoot, inventory, $refs, seq, options);
         }
       });
     }
@@ -82,7 +82,7 @@ function crawl (parent, key, path, pathFromRoot, inventory, $refs, options) {
  * @param {$Refs} $refs
  * @param {$RefParserOptions} options
  */
-function inventory$Ref ($refParent, $refKey, path, pathFromRoot, inventory, $refs, options) {
+function inventory$Ref ($refParent, $refKey, path, pathFromRoot, inventory, $refs, seq, options) {
   if (inventory.some(function (i) { return i.parent === $refParent && i.key === $refKey; })) {
     // This $Ref has already been inventoried, so we don't need to process it again
     return;
@@ -108,11 +108,14 @@ function inventory$Ref ($refParent, $refKey, path, pathFromRoot, inventory, $ref
     value: pointer.value,         // The resolved value of the $ref pointer
     circular: pointer.circular,   // Is this $ref pointer DIRECTLY circular? (i.e. it references itself)
     extended: extended,           // Does this $ref extend its resolved value? (i.e. it has extra properties, in addition to "$ref")
-    external: external            // Does this $ref pointer point to a file other than the main JSON Schema file?
+    external: external,           // Does this $ref pointer point to a file other than the main JSON Schema file?
+    seq: seq                      // Sequence number of this $ref
   });
 
+  var refPathFromRoot = external ? pathFromRoot : $ref.$ref;
+
   // Recursively crawl the resolved value
-  crawl(pointer.value, null, pointer.path, pathFromRoot, inventory, $refs, options);
+  crawl(pointer.value, null, pointer.path, refPathFromRoot, inventory, $refs, seq, options);
 }
 
 /**
@@ -157,8 +160,8 @@ function remap (inventory) {
       return a.depth - b.depth;           // Sort $refs by how close they are to the JSON Schema root
     }
     else {
-      // If all else is equal, use the $ref that's in the "definitions" property
-      return b.pathFromRoot.lastIndexOf('/definitions') - a.pathFromRoot.lastIndexOf('/definitions');
+      // If all else is equal, use the $ref that's in the "definitions" property or sequence number
+      return b.pathFromRoot.lastIndexOf('/definitions') - a.pathFromRoot.lastIndexOf('/definitions') || a.seq - b.seq;
     }
   });
 

--- a/test/specs/external-from-internal/definitions/definitions.json
+++ b/test/specs/external-from-internal/definitions/definitions.json
@@ -1,0 +1,5 @@
+{
+  "thing": {
+    "type": "string"
+  }
+}

--- a/test/specs/external-from-internal/external-from-internal.bundled.js
+++ b/test/specs/external-from-internal/external-from-internal.bundled.js
@@ -1,0 +1,17 @@
+helper.bundled.externalFromInternal = {
+  paths: {
+    $ref: '#/components'
+  },
+  external: {
+    go: {
+      deeper: {
+        $ref: '#/components/test'
+      }
+    }
+  },
+  components: {
+    test: {
+      type: 'string'
+    }
+  }
+};

--- a/test/specs/external-from-internal/external-from-internal.spec.js
+++ b/test/specs/external-from-internal/external-from-internal.spec.js
@@ -1,0 +1,15 @@
+describe('Schema with two external refs to the same value and internal ref before', function () {
+  'use strict';
+  /* details here: https://github.com/BigstickCarpet/json-schema-ref-parser/pull/62 */
+
+  it('should bundle successfully', function () {
+    var parser = new $RefParser();
+    return parser
+      .bundle(path.rel('specs/external-from-internal/external-from-internal.yaml'))
+      .then(function (schema) {
+        expect(schema).to.equal(parser.schema);
+        expect(schema).to.deep.equal(helper.bundled.externalFromInternal);
+      });
+  });
+});
+

--- a/test/specs/external-from-internal/external-from-internal.yaml
+++ b/test/specs/external-from-internal/external-from-internal.yaml
@@ -1,0 +1,9 @@
+paths:
+  $ref: '#/components'
+external:
+  go:
+    deeper:
+      $ref: 'definitions/definitions.json#/thing'
+components:
+  test:
+    $ref: 'definitions/definitions.json#/thing'


### PR DESCRIPTION
Hey @BigstickCarpet,

ReDoc users found an interesting issue in `json-schema-ref-parser`. This is hard to explain so I will just show an example. If we have two files:

`index.yaml`
```yaml
paths:
  $ref: '#/components'
external:
  go:
    deeper:
      $ref: other.yaml#/thing'
components:
  test:
    $ref: 'other.yaml#/thing'
```

and `other.yaml`:
```yaml
thing:
  type: string
```

bundle produced the following output:

```json
{
  "paths": {
    "$ref": "#/components"
  },
  "external": {
    "go": {
      "deeper": {
        "$ref": "#/paths/test" // <--- broken ref here
      }
    }
  },
  "components": {
    "test": {
      "type": "string"
    }
  }
}
```

It actually depends on the deep level of the ref, I believe it has something to sorting order.

I've fixed this in this PR. The fix seems reasonable to me but I'm not sure if this is correct so please check it carefully. Also added test case but not sure if the names are so good.