### PR TITLE
Same file multi definitions

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -167,6 +167,9 @@ function remap (inventory) {
     else if (a.depth !== b.depth) {
       return a.depth - b.depth;               // Sort $refs by how close they are to the JSON Schema root
     }
+    else if (a.pathFromRoot.lastIndexOf('/definitions') === -1 && b.pathFromRoot.lastIndexOf('/definitions') === -1) {
+      return a.pathFromRoot.localeCompare(b.pathFromRoot);
+    }
     else {
       // If all else is equal, use the $ref that's in the "definitions" property
       return b.pathFromRoot.lastIndexOf('/definitions') - a.pathFromRoot.lastIndexOf('/definitions');

--- a/test/specs/complexOrder/complexOrder.bundled.js
+++ b/test/specs/complexOrder/complexOrder.bundled.js
@@ -1,0 +1,49 @@
+helper.bundled.complexOrder = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  properties: {
+    actions: {
+      type: 'object',
+      properties: {
+        affirmativeAction: {
+          type: 'object',
+          properties: {
+            $id: 'text_assets',
+            oneOf: [
+              {
+                $ref: '#/properties/actions/properties/affirmativeAction/properties/definitions/asset'
+              },
+              {
+                $ref: '#/properties/actions/properties/affirmativeAction/properties/definitions/asset'
+              }
+            ],
+            definitions: {
+              switchWrapper: {
+                type: 'object',
+                $ref: '#/properties/actions/properties/affirmativeAction/properties/definitions/switch'
+              },
+              asset: {
+                type: 'object',
+                $id: 'asset_action',
+                properties: {
+                  label: {
+                    $ref: '#/properties/actions/properties/affirmativeAction/properties'
+                  }
+                }
+              },
+              switch: {
+                type: 'array',
+                $ref: '#/properties/actions/properties/affirmativeAction/properties/definitions/asset'
+              }
+            }
+          }
+        },
+        negativeAction: {
+          $ref: '#/properties/actions/properties/affirmativeAction'
+        },
+        prevAction: {
+          $ref: '#/properties/actions/properties/affirmativeAction'
+        }
+      }
+    }
+  }
+};

--- a/test/specs/complexOrder/complexOrder.spec.js
+++ b/test/specs/complexOrder/complexOrder.spec.js
@@ -1,0 +1,14 @@
+describe('$refs that are in the same file but also circular', function () {
+  'use strict';
+
+  it('should bundle successfully', function () {
+    var parser = new $RefParser();
+
+    return parser
+      .bundle(path.rel('specs/complexOrder/definitions/root.json'))
+      .then(function (schema) {
+        expect(schema).to.deep.equal(parser.schema);
+        expect(schema).to.deep.equal(helper.bundled.complexOrder);
+      });
+  });
+});

--- a/test/specs/complexOrder/definitions/action.json
+++ b/test/specs/complexOrder/definitions/action.json
@@ -1,0 +1,8 @@
+{
+    "$id": "asset_action",
+    "properties": {
+        "label": {
+            "$ref": "text_assets.json"
+        }
+    }
+}

--- a/test/specs/complexOrder/definitions/def.json
+++ b/test/specs/complexOrder/definitions/def.json
@@ -1,0 +1,29 @@
+{
+    "$id": "def",
+    "definitions": {
+        "container": {
+            "properties": {
+                "actions": {
+                    "type": "object",
+                    "properties": {
+                        "affirmativeAction": {
+                            "$ref": "#/definitions/actions"
+                        },
+                        "negativeAction": {
+                            "$ref": "#/definitions/actions"
+                        },
+                        "prevAction": {
+                            "$ref": "#/definitions/actions"
+                        }
+                    }
+                }
+            }
+        },
+        "actions": {
+            "type": "object",
+            "properties": {
+                "$ref": "text_assets.json"
+            }
+        }
+    }
+}

--- a/test/specs/complexOrder/definitions/root.json
+++ b/test/specs/complexOrder/definitions/root.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "def.json#/definitions/container"
+}

--- a/test/specs/complexOrder/definitions/text_assets.json
+++ b/test/specs/complexOrder/definitions/text_assets.json
@@ -1,0 +1,26 @@
+{
+    "$id": "text_assets",
+    "oneOf": [
+      {
+        "$ref": "#/definitions/asset"
+      },
+      {
+        "$ref": "#/definitions/asset"
+      }
+    ],
+    "definitions": {
+      "switchWrapper": {
+        "type": "object",
+        "$ref": "#/definitions/switch"
+      },
+      "asset": {
+        "type": "object",
+        "$ref": "action.json"
+      },
+      "switch": {
+        "type": "array",
+        "$ref": "#/definitions/asset"
+      }
+    }
+  }
+  


### PR DESCRIPTION
When there is sufficiently complicated Schema, bundle was overwritting $ref paths. 

I have added 1 extra check in the sort function to fix this. Now if the path from root contains no references to /definitions the paths are ordered alphabetically.

closes #67 