### PR TITLE
When the parser is unable to resolve a path, give the user supplied path in the error.

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -17,7 +17,7 @@ var $Ref = require('./ref'),
  * @param {string} path
  * @constructor
  */
-function Pointer ($ref, path) {
+function Pointer ($ref, path, originalPath) {
   /**
    * The {@link $Ref} object that contains this {@link Pointer} object.
    * @type {$Ref}
@@ -30,6 +30,12 @@ function Pointer ($ref, path) {
    * @type {string}
    */
   this.path = path;
+
+  /**
+   * The original path or URL, used for error messages.
+   * @type {string}
+   */
+  this.originalPath = originalPath || path;
 
   /**
    * The value of the JSON pointer.
@@ -77,7 +83,7 @@ Pointer.prototype.resolve = function (obj, options) {
 
     var token = tokens[i];
     if (this.value[token] === undefined) {
-      throw ono.syntax('Error resolving $ref pointer "%s". \nToken "%s" does not exist.', this.path, token);
+      throw ono.syntax('Error resolving $ref pointer "%s". \nToken "%s" does not exist.', this.originalPath, token);
     }
     else {
       this.value = this.value[token];

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -75,10 +75,11 @@ $Ref.prototype.get = function (path, options) {
  *
  * @param {string} path - The full path being resolved, optionally with a JSON pointer in the hash
  * @param {$RefParserOptions} options
+ * @param {string} [originalPath] - The original, unmodified path being resolved
  * @returns {Pointer}
  */
-$Ref.prototype.resolve = function (path, options) {
-  var pointer = new Pointer(this, path);
+$Ref.prototype.resolve = function (path, options, originalPath) {
+  var pointer = new Pointer(this, path, originalPath);
   return pointer.resolve(this.value, options);
 };
 

--- a/lib/refs.js
+++ b/lib/refs.js
@@ -106,15 +106,15 @@ $Refs.prototype.get = function (path, options) {
  * @param {*} value - The value to assign
  */
 $Refs.prototype.set = function (path, value) {
-  path = url.resolve(this._root$Ref.path, path);
-  var withoutHash = url.stripHash(path);
+  var absPath = url.resolve(this._root$Ref.path, path);
+  var withoutHash = url.stripHash(absPath);
   var $ref = this._$refs[withoutHash];
 
   if (!$ref) {
     throw ono('Error resolving $ref pointer "%s". \n"%s" not found.', path, withoutHash);
   }
 
-  $ref.set(path, value);
+  $ref.set(absPath, value);
 };
 
 /**
@@ -146,15 +146,15 @@ $Refs.prototype._add = function (path, value) {
  * @protected
  */
 $Refs.prototype._resolve = function (path, options) {
-  path = url.resolve(this._root$Ref.path, path);
-  var withoutHash = url.stripHash(path);
+  var absPath = url.resolve(this._root$Ref.path, path);
+  var withoutHash = url.stripHash(absPath);
   var $ref = this._$refs[withoutHash];
 
   if (!$ref) {
     throw ono('Error resolving $ref pointer "%s". \n"%s" not found.', path, withoutHash);
   }
 
-  return $ref.resolve(path, options);
+  return $ref.resolve(absPath, options, path);
 };
 
 /**

--- a/test/specs/refs.spec.js
+++ b/test/specs/refs.spec.js
@@ -251,7 +251,7 @@ describe('$Refs object', function () {
         .catch(function (err) {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.message).to.equal(
-            'Error resolving $ref pointer "' + encodeURI(path.abs('specs/external/definitions/name.yaml')) + '#/". ' +
+            'Error resolving $ref pointer "definitions/name.yaml#/". ' +
             '\nToken "" does not exist.'
           );
         });
@@ -279,7 +279,7 @@ describe('$Refs object', function () {
         .catch(function (err) {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.message).to.equal(
-            'Error resolving $ref pointer "' + encodeURI(path.abs('specs/external/foo-bar.yaml')) + '#/some/value". ' +
+            'Error resolving $ref pointer "foo-bar.yaml#/some/value". ' +
             '\n"' + encodeURI(path.abs('specs/external/foo-bar.yaml')) + '" not found.'
           );
         });
@@ -294,7 +294,7 @@ describe('$Refs object', function () {
         .catch(function (err) {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.message).to.equal(
-            'Error resolving $ref pointer "' + encodeURI(path.abs('specs/external/external.yaml')) + '#/foo/bar". ' +
+            'Error resolving $ref pointer "external.yaml#/foo/bar". ' +
             '\nToken "foo" does not exist.'
           );
         });
@@ -339,7 +339,7 @@ describe('$Refs object', function () {
         .catch(function (err) {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.message).to.equal(
-            'Error resolving $ref pointer "' + encodeURI(path.abs('specs/external/foo-bar.yaml')) + '#/some/path". ' +
+            'Error resolving $ref pointer "foo-bar.yaml#/some/path". ' +
             '\n"' + encodeURI(path.abs('specs/external/foo-bar.yaml')) + '" not found.'
           );
         });


### PR DESCRIPTION
This is an attempt to fix BigstickCarpet/swagger-parser#76.

I'm a little out of my depth here but as far as I can tell this change should work in all-cases.