### PR TITLE
chore: moving karma-edge-launcher to dev dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5034,6 +5034,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
       "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
+      "dev": true,
       "requires": {
         "edge-launcher": "1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",
     "karma-coverage": "^1.1.1",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.1.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
@@ -77,7 +78,6 @@
     "call-me-maybe": "^1.0.1",
     "debug": "^3.1.0",
     "js-yaml": "^3.11.0",
-    "karma-edge-launcher": "^0.4.2",
     "ono": "^4.0.3"
   }
 }


### PR DESCRIPTION
I suspect we don't need `karma-edge-launcher` in production.