### PR TITLE
fix refs components decoding

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -167,7 +167,7 @@ Pointer.parse = function (path) {
 
   // Decode each part, according to RFC 6901
   for (var i = 0; i < pointer.length; i++) {
-    pointer[i] = decodeURI(pointer[i].replace(escapedSlash, '/').replace(escapedTilde, '~'));
+    pointer[i] = decodeURIComponent(pointer[i].replace(escapedSlash, '/').replace(escapedTilde, '~'));
   }
 
   if (pointer[0] !== '') {


### PR DESCRIPTION
The following ref was incorrectly resolved by the `Pointer.parse` method:

```js
Pointer.parse("#/paths/~1user/application~1vnd.example%2Bjson/schema")
// returns ["paths", "/user", "application/vnd.example%2Bjson", "schema"]
```

Note that `+` in `application/vnd.example%2Bjson` is not decoded.
The reason is usage of `decodeURI`. Instead, `decodeURIComponent` should be used (tokens are components of the pointer)