### PR TITLE
fix: add main property back to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "types": "dist/lib/index.d.ts",
   "module": "dist/lib/index.js",
+  "main": "dist/lib/index.js",
   "scripts": {
     "prepublishOnly": "yarn build",
     "lint": "eslint lib",


### PR DESCRIPTION
The "main" was removed (maybe accidentally?) [here](https://github.com/APIDevTools/json-schema-ref-parser/commit/fbb56b5b60b24ca0379ee044a61523985447ff50)
Adding it back fixes this [issue](https://github.com/APIDevTools/json-schema-ref-parser/issues/399)