### PR TITLE
fix: resolve ESLint errors

### DIFF
--- a/lib/dereference.ts
+++ b/lib/dereference.ts
@@ -115,7 +115,7 @@ function crawl<S extends object = JSONSchema, O extends ParserOptions<S> = Parse
           }
 
           const value = obj[key];
-          let circular = false;
+          let circular;
 
           if ($Ref.isAllowed$Ref(value, options)) {
             dereferenced = dereference$Ref(

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -91,7 +91,7 @@ async function readFile<S extends object = JSONSchema, O extends ParserOptions<S
       throw new UnmatchedResolverError(file.url);
     } else if (!err || !("error" in err)) {
       // Throw a generic, friendly error.
-      throw new SyntaxError(`Unable to resolve $ref pointer "${file.url}"`);
+      throw new SyntaxError(`Unable to resolve $ref pointer "${file.url}"`, { cause: err });
     }
     // Throw the original error, if it's one of our own (user-friendly) errors.
     else if (err.error instanceof ResolverError) {
@@ -143,7 +143,7 @@ async function parseFile<S extends object = JSONSchema, O extends ParserOptions<
     } else if (err && err.message && err.message.startsWith("Error parsing")) {
       throw err;
     } else if (!err || !("error" in err)) {
-      throw new SyntaxError(`Unable to parse ${file.url}`);
+      throw new SyntaxError(`Unable to parse ${file.url}`, { cause: err });
     } else if (err.error instanceof ParserError) {
       throw err.error;
     } else {


### PR DESCRIPTION
## Summary

- Remove unused circular variable assignment in dereference.ts
- Preserve caught error cause in SyntaxError exceptions in parse.ts

These changes resolve three ESLint violations: one no-useless-assignment error and two preserve-caught-error errors, while maintaining full test coverage.