### PR TITLE
feat: add synchronous dereferenceSync and bundleSync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ JavaScript objects.
 - Maintains object reference equality &mdash; `$ref` pointers to the same value always resolve to the same object
   instance
 - Compatible with Node LTS and beyond, and all major web browsers on Windows, Mac, and Linux
+- Offers synchronous `dereferenceSync` and `bundleSync` methods for schema objects that don't contain external
+  `$ref` pointers &mdash; no `async`/`await` required
 
 ## Example
 
@@ -80,6 +82,13 @@ try {
 } catch (err) {
   console.error(err);
 }
+```
+
+If your schema is already a JavaScript object and doesn't contain any external `$ref` pointers, you can skip
+`async`/`await` entirely:
+
+```javascript
+const schema = $RefParser.dereferenceSync(mySchema);
 ```
 
 For more detailed examples, please see the [API Documentation](https://apidevtools.com/json-schema-ref-parser/docs/)

--- a/docs/ref-parser.md
+++ b/docs/ref-parser.md
@@ -10,7 +10,9 @@ This is the default export of JSON Schema $Ref Parser. You can creates instances
 ##### Methods
 
 - [`dereference()`](#dereferenceschema-options-callback)
+- [`dereferenceSync()`](#dereferencesyncschema-options)
 - [`bundle()`](#bundleschema-options-callback)
+- [`bundleSync()`](#bundlesyncschema-options)
 - [`parse()`](#parseschema-options-callback)
 - [`resolve()`](#resolveschema-options-callback)
 
@@ -73,6 +75,27 @@ console.log(schema.definitions.person.properties.firstName); // => {type: "strin
 schema.definitions.thing === schema.definitions.batmobile; // => true
 ```
 
+### `dereferenceSync(schema, [options])`
+
+- **schema** (_required_) - `object`<br>
+  A JSON Schema object. Unlike [`dereference`](#dereferenceschema-options-callback), file paths and URLs are **not** supported.
+
+- **options** (_optional_) - `object`<br>
+  See [options](options.md) for the full list of options
+
+- **Return Value:** `object`<br>
+  The dereferenced schema object
+
+Synchronously dereferences all `$ref` pointers in the given JSON Schema object, replacing each reference with its resolved value — the same behavior as [`dereference`](#dereferenceschema-options-callback), but without any `async`/`await` or Promises.
+
+Because resolving external references requires I/O (reading files or downloading URLs), this method only accepts a schema **object**, and the schema must not contain any external `$ref` pointers — it throws an error if either constraint is violated. Internal `$ref` pointers (`#/...`) and references to embedded schema resources (sub-schemas with their own `$id`) are fully supported. Since no I/O is performed, this method behaves identically in Node.js and browsers.
+
+```javascript
+const schema = $RefParser.dereferenceSync(mySchemaObject);
+
+console.log(schema.definitions.person.properties.firstName); // => {type: "string"}
+```
+
 ### `bundle(schema, [options], [callback])`
 
 - **schema** (_required_) - `string` or `object`<br>
@@ -94,6 +117,25 @@ This also eliminates the risk of [circular references](README.md#circular-refs),
 ```javascript
 let schema = await $RefParser.bundle("my-schema.yaml");
 console.log(schema.definitions.person); // => {$ref: "#/definitions/schemas~1people~1Bruce-Wayne.json"}
+```
+
+### `bundleSync(schema, [options])`
+
+- **schema** (_required_) - `object`<br>
+  A JSON Schema object. Unlike [`bundle`](#bundleschema-options-callback), file paths and URLs are **not** supported.
+
+- **options** (_optional_) - `object`<br>
+  See [options](options.md) for the full list of options
+
+- **Return Value:** `object`<br>
+  The bundled schema object
+
+Synchronously bundles all `$ref` pointers in the given JSON Schema object, producing a schema that only has _internal_ `$ref` pointers — the same behavior as [`bundle`](#bundleschema-options-callback), but without any `async`/`await` or Promises.
+
+The same constraints as [`dereferenceSync`](#dereferencesyncschema-options) apply: the schema must be an **object** and must not contain any external `$ref` pointers, since resolving those requires I/O. Since no I/O is performed, this method behaves identically in Node.js and browsers.
+
+```javascript
+const schema = $RefParser.bundleSync(mySchemaObject);
 ```
 
 ### `parse(schema, [options], [callback])`

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,8 @@
 import $Refs from "./refs.js";
 import _parse from "./parse.js";
 import normalizeArgs from "./normalize-args.js";
-import resolveExternal from "./resolve-external.js";
+import type { NormalizedArguments } from "./normalize-args.js";
+import resolveExternal, { assertNoUnresolvedExternalRefs } from "./resolve-external.js";
 import _bundle from "./bundle.js";
 import _dereference from "./dereference.js";
 import * as url from "./util/url.js";
@@ -300,6 +301,43 @@ export class $RefParser<S extends object = JSONSchema, O extends ParserOptions<S
   }
 
   /**
+   * Synchronously bundles all `$ref` pointers in the given JSON Schema object, producing a schema that only has internal `$ref` pointers.
+   *
+   * Unlike `bundle()`, this method only accepts a schema **object** (not a file path or URL), and the schema must not contain any external `$ref` pointers, since resolving external references requires I/O. Because no I/O is performed, this method works the same in Node.js and browsers.
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns The bundled schema object
+   */
+  public static bundleSync<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>>(
+    schema: S | JSONSchema | unknown,
+    options?: O,
+  ): S;
+  static bundleSync<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>>(): S {
+    const instance = new $RefParser<S, O>();
+    return instance.bundleSync.apply(instance, arguments as any);
+  }
+
+  /**
+   * Synchronously bundles all `$ref` pointers in the given JSON Schema object, producing a schema that only has internal `$ref` pointers.
+   *
+   * Unlike `bundle()`, this method only accepts a schema **object** (not a file path or URL), and the schema must not contain any external `$ref` pointers, since resolving external references requires I/O. Because no I/O is performed, this method works the same in Node.js and browsers.
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns The bundled schema object
+   */
+  public bundleSync(schema: S | JSONSchema | unknown, options?: O): S;
+  bundleSync() {
+    const args = normalizeArgs<S, O>(arguments);
+
+    this.resolveSync(args, "bundle");
+    _bundle<S, O>(this, args.options);
+    finalize(this);
+    return this.schema!;
+  }
+
+  /**
    * Bundles all referenced files/URLs into a single schema that only has internal `$ref` pointers. This lets you split-up your schema however you want while you're building it, but easily combine all those files together when it's time to package or distribute the schema to other people. The resulting schema size will be small, since it will still contain internal JSON references rather than being fully-dereferenced.
    *
    * This also eliminates the risk of circular references, so the schema can be safely serialized using `JSON.stringify()`.
@@ -372,6 +410,70 @@ export class $RefParser<S extends object = JSONSchema, O extends ParserOptions<S
   }
 
   /**
+   * Synchronously dereferences all `$ref` pointers in the given JSON Schema object, replacing each reference with its resolved value.
+   *
+   * Unlike `dereference()`, this method only accepts a schema **object** (not a file path or URL), and the schema must not contain any external `$ref` pointers, since resolving external references requires I/O. Because no I/O is performed, this method works the same in Node.js and browsers.
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns The dereferenced schema object
+   */
+  public static dereferenceSync<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>>(
+    schema: S | JSONSchema | unknown,
+    options?: O,
+  ): S;
+  static dereferenceSync<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>>(): S {
+    const instance = new $RefParser<S, O>();
+    return instance.dereferenceSync.apply(instance, arguments as any);
+  }
+
+  /**
+   * Synchronously dereferences all `$ref` pointers in the given JSON Schema object, replacing each reference with its resolved value.
+   *
+   * Unlike `dereference()`, this method only accepts a schema **object** (not a file path or URL), and the schema must not contain any external `$ref` pointers, since resolving external references requires I/O. Because no I/O is performed, this method works the same in Node.js and browsers.
+   *
+   * @param schema A JSON Schema object
+   * @param options (optional)
+   * @returns The dereferenced schema object
+   */
+  public dereferenceSync(schema: S | JSONSchema | unknown, options?: O): S;
+  dereferenceSync() {
+    const args = normalizeArgs<S, O>(arguments);
+
+    this.resolveSync(args, "dereference");
+    _dereference(this, args.options);
+    finalize(this);
+    return this.schema!;
+  }
+
+  /**
+   * Synchronously resolves the given schema object, so that all of its internal `$ref` pointers can be
+   * dereferenced or bundled without performing any I/O. Throws if the schema is not an object, or if it
+   * contains any external `$ref` pointers, since resolving those requires I/O.
+   */
+  private resolveSync(args: NormalizedArguments<S, O>, method: "dereference" | "bundle") {
+    if (!args.schema || typeof args.schema !== "object") {
+      throw new Error(
+        `Expected a schema object. ${method}Sync only supports schema objects; to ${method} a file path or URL, use the asynchronous ${method} method instead. Got ${args.path || args.schema}`,
+      );
+    }
+
+    // Reset everything
+    this.schema = null;
+    this.$refs = new $Refs();
+
+    const path = url.resolve(url.cwd(), args.path);
+    const $ref = this.$refs._add(path);
+    $ref.value = args.schema;
+    $ref.pathType = "http";
+    $ref.dynamicIdScope = usesDynamicIdScope($ref.value);
+    registerSchemaResources(this.$refs, $ref.path!, $ref.value, $ref.pathType, $ref.dynamicIdScope);
+    this.schema = args.schema;
+
+    assertNoUnresolvedExternalRefs(this, args.options, method);
+  }
+
+  /**
    * Dereferences all `$ref` pointers in the JSON Schema, replacing each reference with its resolved value. This results in a schema object that does not contain any `$ref` pointers. Instead, it's a normal JavaScript object tree that can easily be crawled and used just like any other JavaScript object. This is great for programmatic usage, especially when using tools that don't understand JSON references.
    *
    * The dereference method maintains object reference equality, meaning that all `$ref` pointers that point to the same object will be replaced with references to the same object. Again, this is great for programmatic usage, but it does introduce the risk of circular references, so be careful if you intend to serialize the schema using `JSON.stringify()`. Consider using the bundle method instead, which does not create circular references.
@@ -421,7 +523,9 @@ function finalize<S extends object = JSONSchema, O extends ParserOptions<S> = Pa
 export const parse = $RefParser.parse;
 export const resolve = $RefParser.resolve;
 export const bundle = $RefParser.bundle;
+export const bundleSync = $RefParser.bundleSync;
 export const dereference = $RefParser.dereference;
+export const dereferenceSync = $RefParser.dereferenceSync;
 
 export {
   UnmatchedResolverError,

--- a/lib/resolve-external.ts
+++ b/lib/resolve-external.ts
@@ -2,7 +2,7 @@ import $Ref from "./ref.js";
 import Pointer from "./pointer.js";
 import parse from "./parse.js";
 import * as url from "./util/url.js";
-import { isHandledError } from "./util/errors.js";
+import { isHandledError, JSONParserError } from "./util/errors.js";
 import { getSchemaBasePath } from "./util/schema-resources.js";
 import type $Refs from "./refs.js";
 import type { ParserOptions } from "./options.js";
@@ -142,11 +142,7 @@ async function resolve$Ref<S extends object = JSONSchema, O extends ParserOption
     if (typeof reference === "string") {
       parseTarget.reference = reference;
     }
-    const result = await parse(
-      parseTarget,
-      $refs,
-      options,
-    );
+    const result = await parse(parseTarget, $refs, options);
 
     // Crawl the parsed value
     // console.log('Resolving $ref pointers in %s', withoutHash);
@@ -176,4 +172,83 @@ async function resolve$Ref<S extends object = JSONSchema, O extends ParserOption
     return [];
   }
 }
+/**
+ * Synchronously crawls the JSON schema and throws if it contains any external JSON reference
+ * whose value is not already available in {@link $RefParser#$refs}. The synchronous API cannot
+ * perform the I/O required to resolve external references, so they must either be absent or
+ * already registered (e.g. embedded schema resources with their own `$id`).
+ *
+ * @param parser
+ * @param options
+ */
+export function assertNoUnresolvedExternalRefs<
+  S extends object = JSONSchema,
+  O extends ParserOptions<S> = ParserOptions<S>,
+>(parser: $RefParser<S, O>, options: O, method: "dereference" | "bundle") {
+  if (!options.resolve?.external) {
+    // External references won't be resolved, so there's nothing to check
+    return;
+  }
+
+  const rootScopeBase = parser.$refs._root$Ref.dynamicIdScope
+    ? getSchemaBasePath(parser.$refs._root$Ref.path!, parser.schema)
+    : parser.$refs._root$Ref.path!;
+  crawlForUnresolvedExternalRefs(
+    parser.schema,
+    parser.$refs._root$Ref.path + "#",
+    rootScopeBase,
+    parser.$refs._root$Ref.dynamicIdScope,
+    parser.$refs,
+    options,
+    method,
+    new Set(),
+  );
+}
+
+/**
+ * Recursively crawls the given value, and throws for any external JSON reference that is not
+ * already resolved in `$refs`. Mirrors the traversal and path-resolution rules of {@link crawl}
+ * and {@link resolve$Ref}, but never performs I/O.
+ */
+function crawlForUnresolvedExternalRefs<S extends object = JSONSchema, O extends ParserOptions<S> = ParserOptions<S>>(
+  obj: string | Buffer | S | undefined | null,
+  path: string,
+  scopeBase: string,
+  dynamicIdScope: boolean,
+  $refs: $Refs<S, O>,
+  options: O,
+  method: "dereference" | "bundle",
+  seen: Set<any>,
+) {
+  if (obj && typeof obj === "object" && !ArrayBuffer.isView(obj) && !seen.has(obj)) {
+    seen.add(obj); // Track previously seen objects to avoid infinite recursion
+
+    if ($Ref.isExternal$Ref(obj)) {
+      const reference = (obj as JSONSchema).$ref!;
+      const shouldResolveOnCwd = options.dereference?.externalReferenceResolution === "root";
+      const resolutionBase = shouldResolveOnCwd ? url.cwd() : dynamicIdScope ? scopeBase : path;
+      const resolvedPath = url.resolve(resolutionBase, reference);
+      const withoutHash = url.stripHash(resolvedPath);
+
+      if (!$refs._get$Ref(withoutHash)) {
+        throw new JSONParserError(
+          `Cannot resolve external reference "${reference}" synchronously; use the asynchronous ${method} method instead`,
+          decodeURI(url.stripHash(path)),
+        );
+      }
+    }
+
+    const keys = Object.keys(obj) as string[];
+    for (const key of keys) {
+      const keyPath = Pointer.join(path, key);
+      const value = obj[key as keyof typeof obj] as string | JSONSchema | Buffer | undefined;
+      const childScopeBase =
+        dynamicIdScope && value && typeof value === "object" && !ArrayBuffer.isView(value)
+          ? getSchemaBasePath(scopeBase, value)
+          : scopeBase;
+      crawlForUnresolvedExternalRefs(value, keyPath, childScopeBase, dynamicIdScope, $refs, options, method, seen);
+    }
+  }
+}
+
 export default resolveExternal;

--- a/test/specs/sync/sync.spec.ts
+++ b/test/specs/sync/sync.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import $RefParser, { bundleSync, dereferenceSync } from "../../../lib/index.js";
+
+function internalRefsSchema() {
+  return {
+    type: "object",
+    definitions: {
+      name: {
+        title: "name",
+        type: "string",
+      },
+      person: {
+        type: "object",
+        properties: {
+          name: { $ref: "#/definitions/name" },
+        },
+      },
+    },
+    properties: {
+      name: { $ref: "#/definitions/name" },
+      person: { $ref: "#/definitions/person" },
+    },
+  };
+}
+
+describe("dereferenceSync", () => {
+  it("should dereference a schema object with internal $refs", () => {
+    const parser = new $RefParser();
+    const schema = parser.dereferenceSync(internalRefsSchema());
+
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal({
+      type: "object",
+      definitions: {
+        name: {
+          title: "name",
+          type: "string",
+        },
+        person: {
+          type: "object",
+          properties: {
+            name: { title: "name", type: "string" },
+          },
+        },
+      },
+      properties: {
+        name: { title: "name", type: "string" },
+        person: {
+          type: "object",
+          properties: {
+            name: { title: "name", type: "string" },
+          },
+        },
+      },
+    });
+
+    // Reference equality, same as the async dereference
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.name).to.equal(schema.definitions.name);
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.person.properties.name).to.equal(schema.definitions.name);
+
+    expect(parser.$refs.circular).to.equal(false);
+  });
+
+  it("should be callable as a static method", () => {
+    const schema = $RefParser.dereferenceSync(internalRefsSchema());
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.name).to.deep.equal({ title: "name", type: "string" });
+  });
+
+  it("should be callable as a named export", () => {
+    const schema = dereferenceSync(internalRefsSchema());
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.name).to.deep.equal({ title: "name", type: "string" });
+  });
+
+  it("should throw when given a file path instead of a schema object", () => {
+    const parser = new $RefParser();
+
+    expect(() => parser.dereferenceSync("test/specs/internal/internal.yaml")).to.throw(
+      "Expected a schema object. dereferenceSync only supports schema objects; to dereference a file path or URL, use the asynchronous dereference method instead",
+    );
+  });
+
+  it("should throw when the schema contains an external $ref", () => {
+    const parser = new $RefParser();
+    const schema = {
+      type: "object",
+      properties: {
+        person: { $ref: "definitions/person.yaml" },
+      },
+    };
+
+    expect(() => parser.dereferenceSync(schema)).to.throw(
+      'Cannot resolve external reference "definitions/person.yaml" synchronously; use the asynchronous dereference method instead',
+    );
+  });
+
+  it("should dereference circular internal $refs and set the circular flag", () => {
+    const parser = new $RefParser();
+    const schema = parser.dereferenceSync({
+      definitions: {
+        person: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            spouse: { $ref: "#/definitions/person" },
+          },
+        },
+      },
+    });
+
+    expect(parser.$refs.circular).to.equal(true);
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.definitions.person.properties.spouse).to.equal(schema.definitions.person);
+  });
+
+  it("should dereference a compound document with embedded schema resources", () => {
+    const parser = new $RefParser();
+    const schema = parser.dereferenceSync({
+      $id: "https://example.com/schemas/customer",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        shipping_address: { $ref: "/schemas/address" },
+      },
+      $defs: {
+        address: {
+          $id: "https://example.com/schemas/address",
+          type: "object",
+          properties: {
+            state: { $ref: "#/definitions/state" },
+          },
+          definitions: {
+            state: { enum: ["CA", "NY"] },
+          },
+        },
+      },
+    });
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.shipping_address).to.equal(schema.$defs.address);
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.$defs.address.properties.state).to.deep.equal({ enum: ["CA", "NY"] });
+  });
+
+  it("should produce the same result as the asynchronous dereference method", async () => {
+    const compoundSchema = () => ({
+      $id: "https://example.com/schemas/customer",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        shipping_address: { $ref: "/schemas/address" },
+        name: { $ref: "#/$defs/name" },
+      },
+      $defs: {
+        name: { type: "string" },
+        address: {
+          $id: "https://example.com/schemas/address",
+          type: "object",
+          properties: {
+            state: { $ref: "#/definitions/state" },
+          },
+          definitions: {
+            state: { enum: ["CA", "NY"] },
+          },
+        },
+      },
+    });
+
+    const syncResult = new $RefParser().dereferenceSync(compoundSchema());
+    const asyncResult = await new $RefParser().dereference(compoundSchema());
+
+    expect(syncResult).to.deep.equal(asyncResult);
+  });
+});
+
+describe("bundleSync", () => {
+  it("should produce the same result as the asynchronous bundle method", async () => {
+    const syncResult = new $RefParser().bundleSync(internalRefsSchema());
+    const asyncResult = await new $RefParser().bundle(internalRefsSchema());
+
+    expect(syncResult).to.deep.equal(asyncResult);
+  });
+
+  it("should preserve references to embedded schema resources", () => {
+    const parser = new $RefParser();
+    const schema = parser.bundleSync({
+      $id: "https://example.com/schemas/customer",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        shipping_address: { $ref: "/schemas/address" },
+        billing_address: { $ref: "/schemas/address" },
+      },
+      $defs: {
+        address: {
+          $id: "https://example.com/schemas/address",
+          type: "object",
+          properties: {
+            state: { $ref: "#/definitions/state" },
+          },
+          definitions: {
+            state: { enum: ["CA", "NY"] },
+          },
+        },
+      },
+    });
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.shipping_address.$ref).to.equal("/schemas/address");
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.billing_address.$ref).to.equal("/schemas/address");
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.$defs.address.properties.state.$ref).to.equal("#/definitions/state");
+  });
+
+  it("should throw when the schema contains an external $ref", () => {
+    const parser = new $RefParser();
+    const schema = {
+      type: "object",
+      properties: {
+        person: { $ref: "http://example.com/definitions/person.json" },
+      },
+    };
+
+    expect(() => parser.bundleSync(schema)).to.throw(
+      'Cannot resolve external reference "http://example.com/definitions/person.json" synchronously; use the asynchronous bundle method instead',
+    );
+  });
+
+  it("should throw when given a file path instead of a schema object", () => {
+    const parser = new $RefParser();
+
+    expect(() => parser.bundleSync("test/specs/internal/internal.yaml")).to.throw(
+      "Expected a schema object. bundleSync only supports schema objects; to bundle a file path or URL, use the asynchronous bundle method instead",
+    );
+  });
+
+  it("should be callable as a static method", () => {
+    const schema = $RefParser.bundleSync(internalRefsSchema());
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.name).to.deep.equal({ $ref: "#/definitions/name" });
+  });
+
+  it("should be callable as a named export", () => {
+    const schema = bundleSync(internalRefsSchema());
+
+    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+    expect(schema.properties.name).to.deep.equal({ $ref: "#/definitions/name" });
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> **This PR is AI-generated** — it was written by Claude (model: **Fable 5**, Anthropic) via Claude Code, under the direction and review of @vanhumbeecka.

## Summary

Adds a synchronous API for the common case where the schema is already a JavaScript object and all of its `$ref` pointers can be resolved in memory:

- `dereferenceSync(schema, [options])`
- `bundleSync(schema, [options])`

Both are available as instance methods, static methods, and named exports, mirroring the async API.

## Usage

```javascript
import $RefParser, { dereferenceSync, bundleSync } from "@apidevtools/json-schema-ref-parser";

const mySchema = {
  type: "object",
  definitions: {
    name: { type: "string" },
  },
  properties: {
    firstName: { $ref: "#/definitions/name" },
    lastName: { $ref: "#/definitions/name" },
  },
};

// No async/await needed — usable in constructors, module scope, getters, etc.
const schema = $RefParser.dereferenceSync(mySchema);
console.log(schema.properties.firstName); // => { type: "string" }

// Reference equality is maintained, same as the async API
schema.properties.firstName === schema.properties.lastName; // => true

// Instance methods and named exports work too
const parser = new $RefParser();
parser.dereferenceSync(mySchema);
parser.$refs.circular; // => false

bundleSync(mySchema); // sync counterpart of bundle()

// All existing options are supported
const cloned = dereferenceSync(mySchema, { mutateInputSchema: false });
```

Compound documents (embedded schema resources with their own `$id`) work, including external-looking refs that resolve in memory:

```javascript
const schema = $RefParser.dereferenceSync({
  $id: "https://example.com/schemas/customer",
  $schema: "https://json-schema.org/draft/2020-12/schema",
  type: "object",
  properties: {
    shipping_address: { $ref: "/schemas/address" }, // resolves to the embedded resource below
  },
  $defs: {
    address: {
      $id: "https://example.com/schemas/address",
      type: "object",
    },
  },
});
```

References that would require I/O fail fast with a clear error:

```javascript
$RefParser.dereferenceSync({ $ref: "definitions/person.yaml" });
// JSONParserError: Cannot resolve external reference "definitions/person.yaml"
// synchronously; use the asynchronous dereference method instead

$RefParser.dereferenceSync("my-schema.yaml");
// Error: Expected a schema object. dereferenceSync only supports schema objects;
// to dereference a file path or URL, use the asynchronous dereference method instead
```

## Motivation

A synchronous API has been requested since 2015 (#14, 34 comments; #82 closed as its duplicate). #14 was closed pointing to [json-schema-reader](https://github.com/APIDevTools/json-schema-reader) as the successor with a planned sync option, but that project stalled. Meanwhile users resort to the workaround from that thread — importing `lib/dereference` directly and hand-building the `$refs` map — or to event-loop-blocking wrappers that don't work in browsers.

The core engine (`lib/dereference.ts`, `lib/bundle.ts`, and all pointer/ref logic) is already fully synchronous; only the public API plumbing and the resolver I/O are async. When a schema object with only in-memory-resolvable refs is passed, the async path never touches a resolver — so a sync API requires no changes to the engine at all.

## Scope and design

**Strictly limited to in-memory schemas — deliberately.** This PR does not add sync file reading or any sync resolver plumbing; that boundary is what kept previous attempts from converging.

- Input must be a schema **object**. File paths/URLs throw an `Error` pointing to the async API.
- External `$ref`s that would require I/O throw a `JSONParserError` up front. The check (`assertNoUnresolvedExternalRefs` in `lib/resolve-external.ts`) mirrors the `$id`-scope resolution rules of the async crawler, so **compound documents** — external-looking refs into embedded schema resources with their own `$id` — work fully.
- No changes to `dereference.ts`, `bundle.ts`, or any pointer/ref logic. No new dependencies. The async path is untouched.
- Because no I/O is performed, both methods behave identically in Node.js and browsers.

## Testing

- New `test/specs/sync/sync.spec.ts` (14 tests, written test-first): internal refs with reference equality, circular refs + `$refs.circular` flag, compound documents, sync/async output-parity tests for both methods, and both error guards.
- Full node suite: 491 passed. Browser (jsdom) suite: 458 passed. `tsc --noEmit` and `eslint lib` clean.

## Docs

- New sections in `docs/ref-parser.md`; feature bullet + example in `README.md`.

Closes #14
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)